### PR TITLE
Update TypeScript peerDependency (#1155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "src/*"
   ],
   "peerDependencies": {
-    "typescript": "~3.8.2"
+    "typescript": "~3.9.5"
   },
   "devDependencies": {
     "@bazel/bazel": "^0.29.0",


### PR DESCRIPTION
TypeScript 3.9 was added as a devDependency, but not a peerDependency.